### PR TITLE
Updated iassign.d.ts to avoid error TS7010.

### DIFF
--- a/src/iassign.d.ts
+++ b/src/iassign.d.ts
@@ -53,7 +53,7 @@ declare namespace ImmutableAssign {
 
         // In ES6, you cannot set property on imported module directly, because they are default
         // to readonly, in this case you need to use this method.
-        setOption(option: IIassignOption);
+        setOption(option: IIassignOption): void;
     }
 }
 


### PR DESCRIPTION
Fix `node_modules/immutable-assign/src/iassign.d.ts(56,9): error TS7010: 'setOption', which lacks return-type annotation, implicitly has an 'any' return type.`