### PR TITLE
Use proxy objects to eliminate use of eval()

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,4 @@
         "**/*.css": {"when": "$(basename).less"},
         "**/*.jsx": {"when": "$(basename).tsx"}
     }
-,
-"typescript.check.workspaceVersion": false
 }

--- a/README.md
+++ b/README.md
@@ -468,7 +468,6 @@ var map2 = iassign(
 ## Constraints
 
 * getProp() must be a pure function; I.e., it cannot access anything other than the input parameters. e.g., it must not access "this" or "window" objects. In addition, it must not modify the input parameters. It should only return a property that needs to be updated.
-* getProp() currently does not support comments in the function body, you can work around this by putting comments outside of the function body.
 
 
 ## History

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "immutable-assign",
   "version": "1.0.36",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",
@@ -14,6 +15,10 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
       "integrity": "sha1-1xyW99QdD+2iw4zRToonwEFY30o=",
       "dev": true,
+      "requires": {
+        "mime-types": "2.0.14",
+        "negotiator": "0.4.9"
+      },
       "dependencies": {
         "mime-db": {
           "version": "1.12.0",
@@ -25,7 +30,10 @@
           "version": "2.0.14",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
           "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-db": "1.12.0"
+          }
         }
       }
     },
@@ -34,18 +42,45 @@
       "resolved": "https://registry.npmjs.org/accord/-/accord-0.27.3.tgz",
       "integrity": "sha1-f7kSlwkoXK6oTrNyxOiCAxtxOOg=",
       "dev": true,
+      "requires": {
+        "convert-source-map": "1.5.0",
+        "glob": "7.1.2",
+        "indx": "0.2.3",
+        "lodash.clone": "4.5.0",
+        "lodash.defaults": "4.2.0",
+        "lodash.flatten": "4.4.0",
+        "lodash.merge": "4.6.0",
+        "lodash.partialright": "4.2.1",
+        "lodash.pick": "4.4.0",
+        "lodash.uniq": "4.5.0",
+        "resolve": "1.3.3",
+        "semver": "5.3.0",
+        "uglify-js": "2.8.29",
+        "when": "3.7.8"
+      },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         },
         "semver": {
           "version": "5.3.0",
@@ -72,6 +107,10 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "dev": true,
+      "requires": {
+        "extend": "3.0.1",
+        "semver": "5.0.3"
+      },
       "dependencies": {
         "semver": {
           "version": "5.0.3",
@@ -85,7 +124,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -109,25 +153,51 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "micromatch": "2.3.11"
+      }
     },
     "archiver": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.3.0.tgz",
       "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
       "dev": true,
+      "requires": {
+        "archiver-utils": "1.3.0",
+        "async": "2.4.1",
+        "buffer-crc32": "0.2.13",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "readable-stream": "2.3.1",
+        "tar-stream": "1.5.4",
+        "walkdir": "0.0.11",
+        "zip-stream": "1.2.0"
+      },
       "dependencies": {
         "async": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
           "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
         },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "isarray": {
           "version": "1.0.0",
@@ -139,19 +209,34 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         },
         "readable-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
           "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -168,12 +253,28 @@
       "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
       "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lazystream": "1.0.0",
+        "lodash": "4.17.4",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.1"
+      },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -191,19 +292,34 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         },
         "readable-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
           "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -225,13 +341,19 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-flatten": "1.0.3"
+      }
     },
     "arr-flatten": {
       "version": "1.0.3",
@@ -359,7 +481,10 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "beeper": {
       "version": "1.1.1",
@@ -377,7 +502,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsite": "1.0.0"
+      }
     },
     "binary-extensions": {
       "version": "1.8.0",
@@ -390,6 +518,9 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "dev": true,
+      "requires": {
+        "readable-stream": "2.3.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -401,13 +532,25 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
           "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -436,12 +579,27 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
       "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
       "dev": true,
+      "requires": {
+        "bytes": "2.4.0",
+        "content-type": "1.0.2",
+        "debug": "2.6.7",
+        "depd": "1.1.0",
+        "http-errors": "1.6.1",
+        "iconv-lite": "0.4.15",
+        "on-finished": "2.3.0",
+        "qs": "6.4.0",
+        "raw-body": "2.2.0",
+        "type-is": "1.6.15"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -461,19 +619,31 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
     },
     "buffer-crc32": {
       "version": "0.2.13",
@@ -509,25 +679,52 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "anymatch": "1.3.0",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.2",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
     },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      }
     },
     "clone": {
       "version": "1.0.2",
@@ -551,19 +748,28 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz",
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "component-bind": {
       "version": "1.0.0",
@@ -588,6 +794,12 @@
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.0.tgz",
       "integrity": "sha1-WFhwku8g03y1i68AARLJJ4/3O58=",
       "dev": true,
+      "requires": {
+        "buffer-crc32": "0.2.13",
+        "crc32-stream": "2.0.0",
+        "normalize-path": "2.1.1",
+        "readable-stream": "2.3.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -599,13 +811,25 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
           "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -628,6 +852,11 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
       "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
       "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.0.6",
+        "typedarray": "0.0.6"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -639,7 +868,15 @@
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
         }
       }
     },
@@ -648,12 +885,21 @@
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.2.tgz",
       "integrity": "sha1-aU6NIGgb/kkCgsiriGvpjwn0L+c=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.7",
+        "finalhandler": "1.0.3",
+        "parseurl": "1.3.1",
+        "utils-merge": "1.0.0"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -691,7 +937,14 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
       "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      }
     },
     "crc": {
       "version": "3.4.4",
@@ -704,6 +957,10 @@
       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "dev": true,
+      "requires": {
+        "crc": "3.4.4",
+        "readable-stream": "2.3.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -715,13 +972,25 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
           "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -737,7 +1006,10 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
     },
     "custom-event": {
       "version": "1.0.1",
@@ -750,6 +1022,9 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -769,7 +1044,10 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
       "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "0.7.1"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -799,7 +1077,10 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "1.0.2"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -823,7 +1104,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
       "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs-exists-sync": "0.1.0"
+      }
     },
     "di": {
       "version": "0.0.1",
@@ -836,6 +1120,12 @@
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
       "dev": true,
+      "requires": {
+        "custom-event": "1.0.1",
+        "ent": "2.2.0",
+        "extend": "3.0.1",
+        "void-elements": "2.0.1"
+      },
       "dependencies": {
         "extend": {
           "version": "3.0.1",
@@ -849,19 +1139,31 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.1.14"
+      }
     },
     "duplexify": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
       "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
       "dev": true,
+      "requires": {
+        "end-of-stream": "1.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.1",
+        "stream-shift": "1.0.0"
+      },
       "dependencies": {
         "end-of-stream": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
           "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "1.3.3"
+          }
         },
         "isarray": {
           "version": "1.0.0",
@@ -873,13 +1175,25 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
           "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -896,7 +1210,10 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "edge-launcher": {
       "version": "1.2.2",
@@ -920,31 +1237,66 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
       "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.3.3"
+      }
     },
     "engine.io": {
       "version": "1.6.10",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.10.tgz",
       "integrity": "sha1-+H2E4b0h0aLsf43u8MYgVKzfsno=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "accepts": "1.1.4",
+        "base64id": "0.1.0",
+        "debug": "2.2.0",
+        "engine.io-parser": "1.2.4",
+        "ws": "1.0.1"
+      }
     },
     "engine.io-client": {
       "version": "1.6.9",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.9.tgz",
       "integrity": "sha1-HWrUgEilCDyVCWlDsp0279shJAE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "component-emitter": "1.1.2",
+        "component-inherit": "0.0.3",
+        "debug": "2.2.0",
+        "engine.io-parser": "1.2.4",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parsejson": "0.0.1",
+        "parseqs": "0.0.2",
+        "parseuri": "0.0.4",
+        "ws": "1.0.1",
+        "xmlhttprequest-ssl": "1.5.1",
+        "yeast": "0.1.2"
+      }
     },
     "engine.io-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
       "integrity": "sha1-4Il7C/FOeS1M0qWVBVORnFaUjEI=",
       "dev": true,
+      "requires": {
+        "after": "0.8.1",
+        "arraybuffer.slice": "0.0.6",
+        "base64-arraybuffer": "0.1.2",
+        "blob": "0.0.4",
+        "has-binary": "0.1.6",
+        "utf8": "2.1.0"
+      },
       "dependencies": {
         "has-binary": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
           "integrity": "sha1-JTJvOc+k9hath4eJTjryz7x7bhA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
         }
       }
     },
@@ -959,7 +1311,10 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "prr": "0.0.0"
+      }
     },
     "es6-promise": {
       "version": "4.0.5",
@@ -984,13 +1339,23 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -1029,18 +1394,30 @@
       "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
+      "requires": {
+        "array-slice": "0.2.3",
+        "array-unique": "0.2.1",
+        "braces": "0.1.5"
+      },
       "dependencies": {
         "braces": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "expand-range": "0.1.1"
+          }
         },
         "expand-range": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
           "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-number": "0.1.1",
+            "repeat-string": "0.2.2"
+          }
         },
         "is-number": {
           "version": "0.1.1",
@@ -1060,19 +1437,28 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.3"
+      }
     },
     "expand-tilde": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "extend": {
       "version": "3.0.1",
@@ -1084,19 +1470,31 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extendable": "0.1.1"
+      }
     },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "extract-zip": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
       "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
       "dev": true,
+      "requires": {
+        "concat-stream": "1.5.0",
+        "debug": "0.7.4",
+        "mkdirp": "0.5.0",
+        "yauzl": "2.4.1"
+      },
       "dependencies": {
         "debug": {
           "version": "0.7.4",
@@ -1114,7 +1512,10 @@
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         }
       }
     },
@@ -1128,7 +1529,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
       "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "time-stamp": "1.1.0"
+      }
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1140,7 +1545,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pend": "1.2.0"
+      }
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -1152,19 +1560,38 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
     },
     "finalhandler": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
       "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.7",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -1184,19 +1611,35 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
       "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "detect-file": "0.1.0",
+        "is-glob": "2.0.1",
+        "micromatch": "2.3.11",
+        "resolve-dir": "0.1.1"
+      }
     },
     "fined": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
       "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
       "dev": true,
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.3",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.2.0",
+        "parse-filepath": "1.0.1"
+      },
       "dependencies": {
         "expand-tilde": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "homedir-polyfill": "1.0.1"
+          }
         }
       }
     },
@@ -1222,7 +1665,10 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1234,13 +1680,21 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.15"
+      }
     },
     "fs-access": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "null-check": "1.0.0"
+      }
     },
     "fs-exists-sync": {
       "version": "0.1.0",
@@ -1253,6 +1707,11 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -1274,6 +1733,10 @@
       "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
       "dev": true,
       "optional": true,
+      "requires": {
+        "nan": "2.6.2",
+        "node-pre-gyp": "0.6.36"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -1287,7 +1750,11 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -1307,7 +1774,11 @@
           "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
         },
         "asn1": {
           "version": "0.2.3",
@@ -1355,25 +1826,38 @@
           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
           "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
         },
         "block-stream": {
           "version": "0.0.9",
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
         },
         "boom": {
           "version": "2.10.1",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "brace-expansion": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
           "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
         },
         "buffer-shims": {
           "version": "1.0.0",
@@ -1405,7 +1889,10 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -1430,7 +1917,10 @@
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
         },
         "dashdash": {
           "version": "1.14.1",
@@ -1438,6 +1928,9 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1453,7 +1946,10 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "deep-extend": {
           "version": "0.4.2",
@@ -1480,7 +1976,10 @@
           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "extend": {
           "version": "3.0.1",
@@ -1507,7 +2006,12 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -1519,21 +2023,42 @@
           "version": "1.0.11",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
         },
         "fstream-ignore": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
           "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
         },
         "gauge": {
           "version": "2.7.4",
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
         },
         "getpass": {
           "version": "0.1.7",
@@ -1541,6 +2066,9 @@
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1555,7 +2083,15 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -1575,7 +2111,11 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
         },
         "has-unicode": {
           "version": "2.0.1",
@@ -1589,7 +2129,13 @@
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
         },
         "hoek": {
           "version": "2.16.3",
@@ -1602,13 +2148,22 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
         },
         "inflight": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
         },
         "inherits": {
           "version": "2.0.3",
@@ -1627,7 +2182,10 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -1654,7 +2212,10 @@
           "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
           "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "jsbn": {
           "version": "0.1.1",
@@ -1675,7 +2236,10 @@
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
         },
         "json-stringify-safe": {
           "version": "5.0.1",
@@ -1697,6 +2261,12 @@
           "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1717,13 +2287,19 @@
           "version": "2.1.15",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
         },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
         },
         "minimist": {
           "version": "0.0.8",
@@ -1735,7 +2311,10 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -1749,21 +2328,42 @@
           "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
           "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
         },
         "nopt": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
         },
         "npmlog": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
           "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -1789,7 +2389,10 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -1810,7 +2413,11 @@
           "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
           "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -1851,6 +2458,12 @@
           "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
@@ -1865,20 +2478,56 @@
           "version": "2.2.9",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
           "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
         },
         "request": {
           "version": "2.81.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
         },
         "rimraf": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
         },
         "safe-buffer": {
           "version": "5.0.1",
@@ -1912,7 +2561,10 @@
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "sshpk": {
           "version": "1.13.0",
@@ -1920,6 +2572,17 @@
           "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1934,13 +2597,21 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         },
         "stringstream": {
           "version": "0.0.5",
@@ -1953,7 +2624,10 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -1966,28 +2640,49 @@
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
         },
         "tar-pack": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
           "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
         },
         "tough-cookie": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         },
         "tweetnacl": {
           "version": "0.14.5",
@@ -2021,14 +2716,20 @@
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
           "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
         },
         "wide-align": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
         },
         "wrappy": {
           "version": "1.0.2",
@@ -2042,7 +2743,10 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globule": "0.1.0"
+      }
     },
     "generate-function": {
       "version": "2.0.0",
@@ -2054,13 +2758,19 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2074,37 +2784,68 @@
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
       "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "2.0.10",
+        "once": "1.3.3"
+      }
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      }
     },
     "glob-stream": {
       "version": "3.1.18",
       "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
       "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
       "dev": true,
+      "requires": {
+        "glob": "4.5.3",
+        "glob2base": "0.0.12",
+        "minimatch": "2.0.10",
+        "ordered-read-streams": "0.1.0",
+        "through2": "0.6.5",
+        "unique-stream": "1.0.0"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
         }
       }
     },
@@ -2112,37 +2853,63 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
       "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "gaze": "0.5.2"
+      }
     },
     "glob2base": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
       "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-index": "0.1.1"
+      }
     },
     "global-modules": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "global-prefix": "0.1.5",
+        "is-windows": "0.2.0"
+      }
     },
     "global-prefix": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.4",
+        "is-windows": "0.2.0",
+        "which": "1.2.14"
+      }
     },
     "globule": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
+      "requires": {
+        "glob": "3.1.21",
+        "lodash": "1.0.2",
+        "minimatch": "0.2.14"
+      },
       "dependencies": {
         "glob": {
           "version": "3.1.21",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
+          }
         },
         "graceful-fs": {
           "version": "1.2.3",
@@ -2166,7 +2933,11 @@
           "version": "0.2.14",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
         }
       }
     },
@@ -2174,13 +2945,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
       "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sparkles": "1.0.0"
+      }
     },
     "graceful-fs": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
       "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "natives": "1.1.0"
+      }
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -2192,13 +2969,36 @@
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "archy": "1.0.0",
+        "chalk": "1.1.3",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.8",
+        "interpret": "1.0.3",
+        "liftoff": "2.3.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.8",
+        "pretty-hrtime": "1.0.3",
+        "semver": "4.3.6",
+        "tildify": "1.2.0",
+        "v8flags": "2.1.1",
+        "vinyl-fs": "0.3.14"
+      }
     },
     "gulp-less": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/gulp-less/-/gulp-less-3.3.2.tgz",
       "integrity": "sha1-9mNq3MZhUKiQJxn6WZY/x/hipJo=",
       "dev": true,
+      "requires": {
+        "accord": "0.27.3",
+        "gulp-util": "3.0.8",
+        "less": "2.7.2",
+        "object-assign": "4.1.1",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      },
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
@@ -2213,6 +3013,13 @@
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "dev": true,
+      "requires": {
+        "convert-source-map": "1.5.0",
+        "graceful-fs": "4.1.11",
+        "strip-bom": "2.0.0",
+        "through2": "2.0.3",
+        "vinyl": "1.2.0"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -2224,13 +3031,21 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
         },
         "vinyl": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "1.0.2",
+            "clone-stats": "0.0.1",
+            "replace-ext": "0.0.1"
+          }
         }
       }
     },
@@ -2239,6 +3054,12 @@
       "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-3.1.7.tgz",
       "integrity": "sha1-2IYAqRQVPxHAnJpcqMJWHsdaSXg=",
       "dev": true,
+      "requires": {
+        "gulp-util": "3.0.8",
+        "source-map": "0.5.6",
+        "through2": "2.0.3",
+        "vinyl-fs": "2.4.4"
+      },
       "dependencies": {
         "extend": {
           "version": "3.0.1",
@@ -2250,19 +3071,40 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
+          }
         },
         "glob-stream": {
           "version": "5.3.5",
           "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
           "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
           "dev": true,
+          "requires": {
+            "extend": "3.0.1",
+            "glob": "5.0.15",
+            "glob-parent": "3.1.0",
+            "micromatch": "2.3.11",
+            "ordered-read-streams": "0.3.0",
+            "through2": "0.6.5",
+            "to-absolute-glob": "0.1.1",
+            "unique-stream": "2.2.1"
+          },
           "dependencies": {
             "isarray": {
               "version": "0.0.1",
@@ -2274,7 +3116,13 @@
               "version": "1.0.34",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              }
             },
             "string_decoder": {
               "version": "0.10.31",
@@ -2286,7 +3134,11 @@
               "version": "0.6.5",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
+              }
             }
           }
         },
@@ -2312,7 +3164,10 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
         },
         "isarray": {
           "version": "1.0.0",
@@ -2330,19 +3185,35 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
           "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-stream": "1.1.0",
+            "readable-stream": "2.3.0"
+          }
         },
         "readable-stream": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
           "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -2356,25 +3227,56 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
         },
         "unique-stream": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
           "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "json-stable-stringify": "1.0.1",
+            "through2-filter": "2.0.0"
+          }
         },
         "vinyl": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "1.0.2",
+            "clone-stats": "0.0.1",
+            "replace-ext": "0.0.1"
+          }
         },
         "vinyl-fs": {
           "version": "2.4.4",
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
           "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "duplexify": "3.5.0",
+            "glob-stream": "5.3.5",
+            "graceful-fs": "4.1.11",
+            "gulp-sourcemaps": "1.6.0",
+            "is-valid-glob": "0.3.0",
+            "lazystream": "1.0.0",
+            "lodash.isequal": "4.5.0",
+            "merge-stream": "1.0.1",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "readable-stream": "2.3.0",
+            "strip-bom": "2.0.0",
+            "strip-bom-stream": "1.0.0",
+            "through2": "2.0.3",
+            "through2-filter": "2.0.0",
+            "vali-date": "1.0.0",
+            "vinyl": "1.2.0"
+          }
         }
       }
     },
@@ -2382,25 +3284,57 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
       "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.0.0",
+        "fancy-log": "1.3.0",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
+      }
     },
     "gulplog": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
       "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glogg": "1.0.0"
+      }
     },
     "handlebars": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -2408,19 +3342,31 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "commander": "2.9.0",
+        "is-my-json-valid": "2.16.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-binary": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
       "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
     },
     "has-cors": {
       "version": "1.1.0",
@@ -2438,19 +3384,32 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
       "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sparkles": "1.0.0"
+      }
     },
     "hasha": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-stream": "1.1.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
     },
     "hoek": {
       "version": "2.16.3",
@@ -2462,13 +3421,22 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "parse-passwd": "1.0.0"
+      }
     },
     "http-errors": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
       "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
       "dev": true,
+      "requires": {
+        "depd": "1.1.0",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1"
+      },
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
@@ -2482,19 +3450,33 @@
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
+      }
     },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.0",
+        "sshpk": "1.13.1"
+      }
     },
     "https-proxy-agent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "agent-base": "2.1.1",
+        "debug": "2.2.0",
+        "extend": "3.0.1"
+      }
     },
     "iconv-lite": {
       "version": "0.4.15",
@@ -2531,7 +3513,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.3.3",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -2555,13 +3541,20 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
       "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-relative": "0.2.1",
+        "is-windows": "0.2.0"
+      }
     },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "binary-extensions": "1.8.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -2579,7 +3572,10 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -2597,25 +3593,40 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "is-plain-object": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.3.tgz",
       "integrity": "sha1-wVvz5LZrYtcu+vKSWEhmPsvGGbY=",
       "dev": true,
+      "requires": {
+        "isobject": "3.0.0"
+      },
       "dependencies": {
         "isobject": {
           "version": "3.0.0",
@@ -2647,7 +3658,10 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-unc-path": "0.1.2"
+      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -2665,7 +3679,10 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
       "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "0.1.2"
+      }
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -2708,6 +3725,9 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -2728,12 +3748,35 @@
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.10",
+        "js-yaml": "3.6.1",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.3.3",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.2.14",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "resolve": {
           "version": "1.1.7",
@@ -2745,7 +3788,10 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         },
         "wordwrap": {
           "version": "1.0.0",
@@ -2760,18 +3806,34 @@
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.6.0.tgz",
       "integrity": "sha1-ayLnCIPo5YnUVjRhU7TSBt2+IX8=",
       "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "7.1.2",
+        "jasmine-core": "2.6.4"
+      },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -2785,7 +3847,11 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
       "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "2.7.3"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -2804,7 +3870,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -2823,6 +3892,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -2850,6 +3922,12 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.0.2",
+        "json-schema": "0.2.3",
+        "verror": "1.3.6"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2864,6 +3942,33 @@
       "resolved": "https://registry.npmjs.org/karma/-/karma-1.1.2.tgz",
       "integrity": "sha1-eM0J4KfTghxiMpH9Hsm61al2PIU=",
       "dev": true,
+      "requires": {
+        "bluebird": "3.5.0",
+        "body-parser": "1.17.2",
+        "chokidar": "1.7.0",
+        "colors": "1.1.2",
+        "combine-lists": "1.0.1",
+        "connect": "3.6.2",
+        "core-js": "2.4.1",
+        "di": "0.0.1",
+        "dom-serialize": "2.2.1",
+        "expand-braces": "0.1.2",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "http-proxy": "1.16.2",
+        "isbinaryfile": "3.0.2",
+        "lodash": "3.10.1",
+        "log4js": "0.6.38",
+        "mime": "1.3.6",
+        "minimatch": "3.0.4",
+        "optimist": "0.6.1",
+        "qjobs": "1.1.5",
+        "rimraf": "2.6.1",
+        "socket.io": "1.4.7",
+        "source-map": "0.5.6",
+        "tmp": "0.0.28",
+        "useragent": "2.1.13"
+      },
       "dependencies": {
         "balanced-match": {
           "version": "1.0.0",
@@ -2875,19 +3980,34 @@
           "version": "1.1.8",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
         },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          },
           "dependencies": {
             "minimatch": {
               "version": "3.0.4",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              }
             }
           }
         },
@@ -2907,7 +4027,10 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -2915,7 +4038,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-1.0.1.tgz",
       "integrity": "sha1-vlrnxCZPmgouIuPZhL6zJa2SyMs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs-access": "1.0.1",
+        "which": "1.2.14"
+      }
     },
     "karma-firefox-launcher": {
       "version": "1.0.1",
@@ -2927,7 +4054,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/karma-ie-launcher/-/karma-ie-launcher-1.0.0.tgz",
       "integrity": "sha1-SXmGhCxJAZA0bNifVJTKmDDG1Zw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "karma-jasmine": {
       "version": "1.1.0",
@@ -2939,7 +4069,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz",
       "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4",
+        "phantomjs-prebuilt": "2.1.14"
+      }
     },
     "karma-safari-launcher": {
       "version": "1.0.0",
@@ -2951,7 +4085,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-1.1.0.tgz",
       "integrity": "sha1-PQg89WWdZzarl7zuXYrNhq1SIhI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "q": "1.5.0",
+        "sauce-connect-launcher": "0.17.0",
+        "saucelabs": "1.4.0",
+        "wd": "1.2.0"
+      }
     },
     "kew": {
       "version": "0.7.0",
@@ -2963,13 +4103,19 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -2991,6 +4137,9 @@
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
+      "requires": {
+        "readable-stream": "2.3.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -3002,13 +4151,25 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
           "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -3031,6 +4192,16 @@
       "resolved": "https://registry.npmjs.org/less/-/less-2.7.2.tgz",
       "integrity": "sha1-No1sxz4fsDmBGDKAkYdDxdz5s98=",
       "dev": true,
+      "requires": {
+        "errno": "0.1.4",
+        "graceful-fs": "4.1.11",
+        "image-size": "0.5.5",
+        "mime": "1.3.6",
+        "mkdirp": "0.5.1",
+        "promise": "7.3.1",
+        "request": "2.79.0",
+        "source-map": "0.5.6"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -3045,13 +4216,28 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "liftoff": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.3.0.tgz",
       "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extend": "3.0.1",
+        "findup-sync": "0.4.3",
+        "fined": "1.1.0",
+        "flagged-respawn": "0.3.2",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.mapvalues": "4.6.0",
+        "rechoir": "0.6.2",
+        "resolve": "1.3.3"
+      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -3129,7 +4315,10 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
       "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._root": "3.0.1"
+      }
     },
     "lodash.flatten": {
       "version": "4.4.0",
@@ -3171,7 +4360,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lodash.mapvalues": {
       "version": "4.6.0",
@@ -3207,13 +4401,28 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
+      }
     },
     "lodash.templatesettings": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
       "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
+      }
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -3232,12 +4441,22 @@
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
       "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
       "dev": true,
+      "requires": {
+        "readable-stream": "1.0.34",
+        "semver": "4.3.6"
+      },
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         }
       }
     },
@@ -3270,6 +4489,9 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
+      "requires": {
+        "readable-stream": "2.3.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -3281,13 +4503,25 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
           "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -3309,7 +4543,22 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.3"
+      }
     },
     "mime": {
       "version": "1.3.6",
@@ -3327,13 +4576,19 @@
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "1.27.0"
+      }
     },
     "minimatch": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
       "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -3346,6 +4601,9 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -3365,7 +4623,10 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "duplexer2": "0.0.2"
+      }
     },
     "nan": {
       "version": "2.6.2",
@@ -3390,13 +4651,19 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9"
+      }
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "1.0.2"
+      }
     },
     "null-check": {
       "version": "1.0.0",
@@ -3427,6 +4694,12 @@
       "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
       "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
       "dev": true,
+      "requires": {
+        "array-each": "1.0.1",
+        "array-slice": "1.0.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.0"
+      },
       "dependencies": {
         "array-slice": {
           "version": "1.0.0",
@@ -3438,7 +4711,10 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
         },
         "isobject": {
           "version": "3.0.0",
@@ -3452,31 +4728,48 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
     },
     "object.pick": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
       "integrity": "sha1-tTkr7peC2m2ft9avr1OXefEjTCs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isobject": "2.1.0"
+      }
     },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "once": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
       "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.2"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
@@ -3491,6 +4784,14 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
@@ -3510,7 +4811,12 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
       "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "end-of-stream": "0.1.5",
+        "sequencify": "0.0.7",
+        "stream-consume": "0.1.0"
+      }
     },
     "ordered-read-streams": {
       "version": "0.1.0",
@@ -3534,13 +4840,24 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.1.tgz",
       "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-absolute": "0.2.6",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
+      }
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -3552,19 +4869,28 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
       "integrity": "sha1-mxDGwNglq1ieaFFTgm3go7oni8w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseqs": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
       "integrity": "sha1-nf5wss3aw4i95PNbHyQPpYrb5sc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseuri": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
       "integrity": "sha1-gGWCo5iH4eoY3V4v4OAZAiaOk1A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseurl": {
       "version": "1.3.1",
@@ -3594,7 +4920,10 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
       "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-root-regex": "0.1.2"
+      }
     },
     "path-root-regex": {
       "version": "0.1.2",
@@ -3612,7 +4941,18 @@
       "version": "2.1.14",
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.14.tgz",
       "integrity": "sha1-1T0xH8+30dCN2yQBRVjxGIxRbaA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-promise": "4.0.5",
+        "extract-zip": "1.5.0",
+        "fs-extra": "1.0.0",
+        "hasha": "2.2.0",
+        "kew": "0.7.0",
+        "progress": "1.1.8",
+        "request": "2.79.0",
+        "request-progress": "2.0.1",
+        "which": "1.2.14"
+      }
     },
     "pinkie": {
       "version": "2.0.4",
@@ -3624,7 +4964,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -3661,7 +5004,10 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "asap": "2.0.5"
+      }
     },
     "prr": {
       "version": "0.0.0",
@@ -3699,18 +5045,28 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.5"
+              }
             }
           }
         },
@@ -3718,7 +5074,10 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
         }
       }
     },
@@ -3726,19 +5085,36 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
       "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bytes": "2.4.0",
+        "iconv-lite": "0.4.15",
+        "unpipe": "1.0.0"
+      }
     },
     "readable-stream": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.1",
+        "set-immediate-shim": "1.0.1"
+      },
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
@@ -3762,19 +5138,34 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         },
         "readable-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
           "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -3790,13 +5181,20 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve": "1.3.3"
+      }
     },
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3",
+        "is-primitive": "2.0.0"
+      }
     },
     "remove-trailing-separator": {
       "version": "1.0.2",
@@ -3826,13 +5224,38 @@
       "version": "2.79.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.11.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "2.0.6",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.15",
+        "oauth-sign": "0.8.2",
+        "qs": "6.3.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.4.3",
+        "uuid": "3.1.0"
+      }
     },
     "request-progress": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "throttleit": "1.0.0"
+      }
     },
     "requires-port": {
       "version": "1.0.0",
@@ -3844,25 +5267,38 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-dir": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-tilde": "1.2.2",
+        "global-modules": "0.2.3"
+      }
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      },
       "dependencies": {
         "balanced-match": {
           "version": "1.0.0",
@@ -3874,19 +5310,34 @@
           "version": "1.1.8",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
         },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
         }
       }
     },
@@ -3901,6 +5352,13 @@
       "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-0.17.0.tgz",
       "integrity": "sha1-kI2TEeyvF92bRkehQ1/UogcugM4=",
       "dev": true,
+      "requires": {
+        "adm-zip": "0.4.7",
+        "async": "1.4.0",
+        "https-proxy-agent": "1.0.0",
+        "lodash": "3.10.1",
+        "rimraf": "2.4.3"
+      },
       "dependencies": {
         "async": {
           "version": "1.4.0",
@@ -3912,7 +5370,14 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "lodash": {
           "version": "3.10.1",
@@ -3924,7 +5389,10 @@
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
           "integrity": "sha1-5bUclDekxYKtuVXp8oz42UXicq8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "5.0.15"
+          }
         }
       }
     },
@@ -3932,7 +5400,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.4.0.tgz",
       "integrity": "sha1-uTSpr52ih0s/QKrh/N5QpEZvXzg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "1.0.0"
+      }
     },
     "seamless-immutable": {
       "version": "7.1.2",
@@ -3974,25 +5445,47 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "socket.io": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.7.tgz",
       "integrity": "sha1-krf3y4jFeX1NruJ5/oB12+bT+hw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.2.0",
+        "engine.io": "1.6.10",
+        "has-binary": "0.1.7",
+        "socket.io-adapter": "0.4.0",
+        "socket.io-client": "1.4.6",
+        "socket.io-parser": "2.2.6"
+      }
     },
     "socket.io-adapter": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
       "integrity": "sha1-+5+CqxqmUpC/csNleVW5MKmRok8=",
       "dev": true,
+      "requires": {
+        "debug": "2.2.0",
+        "socket.io-parser": "2.2.2"
+      },
       "dependencies": {
         "socket.io-parser": {
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
           "integrity": "sha1-PXr2tkSX6Va32f53X5mXFgJ/lBc=",
           "dev": true,
+          "requires": {
+            "benchmark": "1.0.0",
+            "component-emitter": "1.1.2",
+            "debug": "0.7.4",
+            "isarray": "0.0.1",
+            "json3": "3.2.6"
+          },
           "dependencies": {
             "debug": {
               "version": "0.7.4",
@@ -4009,6 +5502,19 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.6.tgz",
       "integrity": "sha1-SbC6U379FbgpfIQBbmQuHHx1LD0=",
       "dev": true,
+      "requires": {
+        "backo2": "1.0.2",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.0",
+        "debug": "2.2.0",
+        "engine.io-client": "1.6.9",
+        "has-binary": "0.1.7",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseuri": "0.0.4",
+        "socket.io-parser": "2.2.6",
+        "to-array": "0.1.4"
+      },
       "dependencies": {
         "component-emitter": {
           "version": "1.2.0",
@@ -4023,6 +5529,13 @@
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
       "integrity": "sha1-ON/WHfUNz4qx2eIJEyK/kCuii5k=",
       "dev": true,
+      "requires": {
+        "benchmark": "1.0.0",
+        "component-emitter": "1.1.2",
+        "debug": "2.2.0",
+        "isarray": "0.0.1",
+        "json3": "3.3.2"
+      },
       "dependencies": {
         "json3": {
           "version": "3.3.2",
@@ -4055,6 +5568,16 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -4098,25 +5621,39 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
       "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "first-chunk-stream": "1.0.0",
+        "is-utf8": "0.2.1"
+      }
     },
     "strip-bom-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "dev": true,
+      "requires": {
+        "first-chunk-stream": "1.0.0",
+        "strip-bom": "2.0.0"
+      },
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
         }
       }
     },
@@ -4131,12 +5668,21 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
       "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
       "dev": true,
+      "requires": {
+        "bl": "1.2.1",
+        "end-of-stream": "1.4.0",
+        "readable-stream": "2.3.1",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "end-of-stream": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
           "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "1.4.0"
+          }
         },
         "isarray": {
           "version": "1.0.0",
@@ -4148,19 +5694,34 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         },
         "readable-stream": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
           "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -4183,6 +5744,10 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
+      "requires": {
+        "readable-stream": "2.3.1",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -4194,13 +5759,25 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
           "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -4216,13 +5793,20 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
+      }
     },
     "tildify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
       "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "time-stamp": {
       "version": "1.1.0",
@@ -4240,13 +5824,19 @@
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
     },
     "to-absolute-glob": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extend-shallow": "2.0.1"
+      }
     },
     "to-array": {
       "version": "0.1.4",
@@ -4258,7 +5848,10 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.4.3",
@@ -4277,13 +5870,20 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
       "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.15"
+      },
       "dependencies": {
         "mime-db": {
           "version": "1.27.0",
@@ -4295,7 +5895,10 @@
           "version": "2.1.15",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
         }
       }
     },
@@ -4315,7 +5918,12 @@
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
@@ -4340,7 +5948,11 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "unique-stream": {
       "version": "1.0.0",
@@ -4365,6 +5977,10 @@
       "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.13.tgz",
       "integrity": "sha1-u6Q+iqJNXOuDwpN0c+EC4h33TBA=",
       "dev": true,
+      "requires": {
+        "lru-cache": "2.2.4",
+        "tmp": "0.0.28"
+      },
       "dependencies": {
         "lru-cache": {
           "version": "2.2.4",
@@ -4402,7 +6018,10 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "user-home": "1.1.1"
+      }
     },
     "vali-date": {
       "version": "1.0.0",
@@ -4420,19 +6039,37 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extsprintf": "1.0.2"
+      }
     },
     "vinyl": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
       "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "1.0.2",
+        "clone-stats": "0.0.1",
+        "replace-ext": "0.0.1"
+      }
     },
     "vinyl-fs": {
       "version": "0.3.14",
       "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
       "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
       "dev": true,
+      "requires": {
+        "defaults": "1.0.3",
+        "glob-stream": "3.1.18",
+        "glob-watcher": "0.0.6",
+        "graceful-fs": "3.0.11",
+        "mkdirp": "0.5.1",
+        "strip-bom": "1.0.0",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
+      },
       "dependencies": {
         "clone": {
           "version": "0.2.0",
@@ -4444,19 +6081,33 @@
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
         },
         "vinyl": {
           "version": "0.4.6",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
+          }
         }
       }
     },
@@ -4465,6 +6116,10 @@
       "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
       "integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
       "dev": true,
+      "requires": {
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
+      },
       "dependencies": {
         "clone": {
           "version": "0.2.0",
@@ -4476,19 +6131,33 @@
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "through2": {
           "version": "0.6.5",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
         },
         "vinyl": {
           "version": "0.4.6",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
+          }
         }
       }
     },
@@ -4496,7 +6165,10 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
       "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6"
+      }
     },
     "void-elements": {
       "version": "2.0.1",
@@ -4515,12 +6187,25 @@
       "resolved": "https://registry.npmjs.org/wd/-/wd-1.2.0.tgz",
       "integrity": "sha1-QRLEZX7KWvWT68Bg1UuAyu6gSAc=",
       "dev": true,
+      "requires": {
+        "archiver": "1.3.0",
+        "async": "2.0.1",
+        "lodash": "4.16.2",
+        "mkdirp": "0.5.1",
+        "q": "1.4.1",
+        "request": "2.79.0",
+        "underscore.string": "3.3.4",
+        "vargs": "0.1.0"
+      },
       "dependencies": {
         "async": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
           "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "4.16.2"
+          }
         },
         "lodash": {
           "version": "4.16.2",
@@ -4546,7 +6231,10 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "window-size": {
       "version": "0.1.0",
@@ -4570,7 +6258,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
       "integrity": "sha1-fQsqLljN3YGQOcKcneZQReGzEOk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "options": "0.0.6",
+        "ultron": "1.0.2"
+      }
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.1",
@@ -4588,13 +6280,22 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
+      }
     },
     "yauzl": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fd-slicer": "1.0.1"
+      }
     },
     "yeast": {
       "version": "0.1.2",
@@ -4607,6 +6308,12 @@
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
       "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "dev": true,
+      "requires": {
+        "archiver-utils": "1.3.0",
+        "compress-commons": "1.2.0",
+        "lodash": "4.17.4",
+        "readable-stream": "2.3.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -4618,13 +6325,25 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.1.tgz",
           "integrity": "sha512-u6cxIvtbZcjq2HH71Zc/SRBUl7vbv62szIqmqqGpK3HY5J1c0kR/LUzKUpeoFgMzapvVAlBD+QY56ilWmHi4Nw==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",

--- a/spec/ImmutableAssign2Spec.js
+++ b/spec/ImmutableAssign2Spec.js
@@ -355,10 +355,10 @@
                 var o2 = iassign(o1, function (o) {
                     o.a.b.c[0][0]
                 }, function (ci) { ci.d++; return ci; });
-            }).toThrowError(/has no 'return' keyword/);
+            }).toThrowError(/does not return a part of obj/);
         });
 
-        it("getProp() function has other statements should throw exception", function () {            
+        xit("getProp() function has other statements should throw exception", function () {            
             if (iassign.disableExtraStatementCheck) {
                 return;
             }

--- a/src/iassign.js
+++ b/src/iassign.js
@@ -45,7 +45,6 @@
     }());
     var iassign = _iassign;
     iassign.fp = autoCurry(_iassignFp);
-    iassign.maxGetPropCacheSize = 100;
     iassign.setOption = function (option) {
         copyOption(iassign, option);
     };
@@ -90,8 +89,11 @@
                     return obj;
                 }
             }
-            var getPropFuncInfo = parseGetPropFuncInfo(getProp, option);
-            obj = updateProperty(obj, setProp, newValue, context, getPropFuncInfo, option);
+            var propPath = getPropPath(getProp, obj, context, option);
+            if (!propPath) {
+                throw new Error('getProp() function does not return a part of obj');
+            }
+            obj = updateProperty(obj, setProp, newValue, context, propPath, option);
         }
         if (deepFreeze && (option.freeze || option.freezeOutput)) {
             deepFreeze(obj);
@@ -100,6 +102,47 @@
     }
     function _iassignFp(option, getProp, setProp, context, obj) {
         return _iassign(obj, getProp, setProp, context, option);
+    }
+    function getPropPath(getProp, obj, context, option) {
+        // will be a double map, both original values and proxied objects will have the path indexed
+        var pathMap = new Map();
+        var handlers = {
+            get: function (target, prop) {
+                switch (prop) {
+                    // Allows this object be used as a primitive for self-referential access (e.g. obj.a[obj.b])
+                    // See http://www.adequatelygood.com/Object-to-Primitive-Conversions-in-JavaScript.html
+                    case 'valueOf':
+                        return function () { return target.valueOf(); };
+                    case 'toString':
+                        return function () { return target.toString(); };
+                }
+                var nextValue = target[prop];
+                if (nextValue === undefined || nextValue === null) {
+                    return nextValue;
+                }
+                var nextObj;
+                if (typeof nextValue !== 'object') {
+                    nextObj = {
+                        valueOf: function () { return nextValue; },
+                        toString: function () { return nextValue.toString(); },
+                    };
+                }
+                else {
+                    nextObj = quickCopy(nextValue, prop, option.useConstructor, option.copyFunc);
+                }
+                var prevPath = pathMap.get(target) || [];
+                var nextPath = prevPath.concat(prop);
+                var proxied = new Proxy(nextObj, handlers);
+                pathMap.set(nextObj, nextPath);
+                pathMap.set(proxied, nextPath);
+                return proxied;
+            },
+        };
+        var coreObj = quickCopy(obj, undefined, option.useConstructor, option.copyFunc);
+        coreObj = new Proxy(coreObj, handlers);
+        pathMap.set(coreObj, []);
+        pathMap.set(obj, []);
+        return pathMap.get(getProp(coreObj, context));
     }
     // For performance
     function copyOption(target, option, defaultOption) {
@@ -110,10 +153,6 @@
             target.freezeOutput = defaultOption.freezeOutput;
             target.useConstructor = defaultOption.useConstructor;
             target.copyFunc = defaultOption.copyFunc;
-            target.disableAllCheck = defaultOption.disableAllCheck;
-            target.disableHasReturnCheck = defaultOption.disableHasReturnCheck;
-            target.disableExtraStatementCheck = defaultOption.disableExtraStatementCheck;
-            target.maxGetPropCacheSize = defaultOption.maxGetPropCacheSize;
             target.ignoreIfNoChange = defaultOption.ignoreIfNoChange;
         }
         if (option) {
@@ -132,263 +171,30 @@
             if (option.copyFunc != undefined) {
                 target.copyFunc = option.copyFunc;
             }
-            if (option.disableAllCheck != undefined) {
-                target.disableAllCheck = option.disableAllCheck;
-            }
-            if (option.disableHasReturnCheck != undefined) {
-                target.disableHasReturnCheck = option.disableHasReturnCheck;
-            }
-            if (option.disableExtraStatementCheck != undefined) {
-                target.disableExtraStatementCheck = option.disableExtraStatementCheck;
-            }
-            if (option.maxGetPropCacheSize != undefined) {
-                target.maxGetPropCacheSize = option.maxGetPropCacheSize;
-            }
             if (option.ignoreIfNoChange != undefined) {
                 target.ignoreIfNoChange = option.ignoreIfNoChange;
             }
         }
         return target;
     }
-    function updateProperty(obj, setProp, newValue, context, getPropFuncInfo, option) {
-        var propValue = undefined;
-        for (var propIndex = 0; propIndex < getPropFuncInfo.funcTokens.length; ++propIndex) {
-            var _a = getPropFuncInfo.funcTokens[propIndex], propName = _a.propName, propNameSource = _a.propNameSource, subAccessorText = _a.subAccessorText, getPropName = _a.getPropName;
-            //console.log(propName);
-            if (propIndex <= 0) {
-                propValue = quickCopy(obj, propName, option.useConstructor, option.copyFunc);
-                if (!subAccessorText) {
-                    propValue = option.ignoreIfNoChange ? newValue : setProp(propValue);
-                }
-                obj = propValue;
+    function updateProperty(obj, setProp, newValue, context, propPath, option) {
+        var propValue = quickCopy(obj, undefined, option.useConstructor, option.copyFunc);
+        obj = propValue;
+        if (!propPath.length) {
+            return option.ignoreIfNoChange ? newValue : setProp(propValue);
+        }
+        for (var propIndex = 0; propIndex < propPath.length; ++propIndex) {
+            var propName = propPath[propIndex];
+            var isLast = propIndex + 1 === propPath.length;
+            var prevPropValue = propValue;
+            propValue = propValue[propName];
+            propValue = quickCopy(propValue, propName, option.useConstructor, option.copyFunc);
+            if (isLast) {
+                propValue = option.ignoreIfNoChange ? newValue : setProp(propValue);
             }
-            else {
-                var prevPropValue = propValue;
-                if (propName == undefined) {
-                    propName = getPropName(obj, context);
-                }
-                propValue = propValue[propName];
-                propValue = quickCopy(propValue, propName, option.useConstructor, option.copyFunc);
-                if (!subAccessorText) {
-                    propValue = option.ignoreIfNoChange ? newValue : setProp(propValue);
-                }
-                prevPropValue[propName] = propValue;
-            }
-            //console.log(propValue);
+            prevPropValue[propName] = propValue;
         }
         return obj;
-    }
-    var ePropNameSource;
-    (function (ePropNameSource) {
-        ePropNameSource[ePropNameSource["none"] = 0] = "none";
-        ePropNameSource[ePropNameSource["beforeDot"] = 1] = "beforeDot";
-        ePropNameSource[ePropNameSource["beforeBracket"] = 2] = "beforeBracket";
-        ePropNameSource[ePropNameSource["inBracket"] = 3] = "inBracket";
-        ePropNameSource[ePropNameSource["last"] = 4] = "last";
-    })(ePropNameSource || (ePropNameSource = {}));
-    var getPropCaches = {};
-    var getPropCacheKeys = [];
-    function parseGetPropFuncInfo(func, option) {
-        var funcText = func.toString();
-        var cacheKey = funcText + JSON.stringify(option);
-        var info = getPropCaches[cacheKey];
-        if (getPropCaches[cacheKey]) {
-            return info;
-        }
-        var matches = /\(([^\)]*)\)/.exec(funcText);
-        var objParameterName = undefined;
-        var cxtParameterName = undefined;
-        if (matches) {
-            var parametersText = matches[1];
-            var parameters = parametersText.split(",");
-            objParameterName = parameters[0];
-            cxtParameterName = parameters[1];
-        }
-        if (objParameterName) {
-            objParameterName = objParameterName.trim();
-        }
-        if (cxtParameterName) {
-            cxtParameterName = cxtParameterName.trim();
-        }
-        var bodyStartIndex = funcText.indexOf("{");
-        var bodyEndIndex = funcText.lastIndexOf("}");
-        var bodyText = "";
-        if (bodyStartIndex > -1 && bodyEndIndex > -1) {
-            bodyText = funcText.substring(bodyStartIndex + 1, bodyEndIndex);
-        }
-        else {
-            var arrowIndex = funcText.indexOf("=>");
-            if (arrowIndex > -1) {
-                //console.log("Handle arrow function.");
-                bodyText = "return " + funcText.substring(arrowIndex + 3);
-            }
-            else {
-                throw new Error("Cannot parse function: " + funcText);
-            }
-        }
-        var accessorTextInfo = getAccessorTextInfo(bodyText, option);
-        info = {
-            objParameterName: objParameterName,
-            cxtParameterName: cxtParameterName,
-            bodyText: bodyText,
-            accessorText: accessorTextInfo.accessorText,
-            quotedTextInfos: accessorTextInfo.quotedTextInfos,
-            funcTokens: parseGetPropFuncTokens(accessorTextInfo.accessorText),
-        };
-        postProcessTokens(info);
-        if (option.maxGetPropCacheSize > 0) {
-            getPropCaches[cacheKey] = info;
-            getPropCacheKeys.push(cacheKey);
-            if (getPropCacheKeys.length > option.maxGetPropCacheSize) {
-                debugger;
-                var cacheKeyToRemove = getPropCacheKeys.shift();
-                delete getPropCaches[cacheKeyToRemove];
-            }
-        }
-        return info;
-    }
-    function parseGetPropFuncTokens(accessorText) {
-        var tokens = [];
-        while (accessorText) {
-            var openBracketIndex = accessorText.indexOf("[");
-            var closeBracketIndex = accessorText.indexOf("]");
-            var dotIndex = accessorText.indexOf(".");
-            var propName = "";
-            var propNameSource = ePropNameSource.none;
-            // if (dotIndex == 0) {
-            //     accessorText = accessorText.substr(dotIndex + 1);
-            //     continue;
-            // }
-            if (openBracketIndex > -1 && closeBracketIndex <= -1) {
-                throw new Error("Found open bracket but not close bracket.");
-            }
-            if (openBracketIndex <= -1 && closeBracketIndex > -1) {
-                throw new Error("Found close bracket but not open bracket.");
-            }
-            if (dotIndex > -1 && (dotIndex < openBracketIndex || openBracketIndex <= -1)) {
-                propName = accessorText.substr(0, dotIndex);
-                accessorText = accessorText.substr(dotIndex + 1);
-                propNameSource = ePropNameSource.beforeDot;
-            }
-            else if (openBracketIndex > -1 && (openBracketIndex < dotIndex || dotIndex <= -1)) {
-                if (openBracketIndex > 0) {
-                    propName = accessorText.substr(0, openBracketIndex);
-                    accessorText = accessorText.substr(openBracketIndex);
-                    propNameSource = ePropNameSource.beforeBracket;
-                }
-                else {
-                    propName = accessorText.substr(openBracketIndex + 1, closeBracketIndex - 1);
-                    accessorText = accessorText.substr(closeBracketIndex + 1);
-                    propNameSource = ePropNameSource.inBracket;
-                }
-            }
-            else {
-                propName = accessorText;
-                accessorText = "";
-                propNameSource = ePropNameSource.last;
-            }
-            propName = propName.trim();
-            if (propName == "") {
-                continue;
-            }
-            //console.log(propName);
-            tokens.push({
-                propName: propName,
-                propNameSource: propNameSource,
-                subAccessorText: accessorText,
-            });
-        }
-        return tokens;
-    }
-    function postProcessTokens(getPropFuncInfo) {
-        var _loop_1 = function () {
-            var token = getPropFuncInfo.funcTokens[propIndex];
-            var propName = token.propName, propNameSource = token.propNameSource, subAccessorText = token.subAccessorText;
-            if (propNameSource == ePropNameSource.inBracket && isNaN(propName)) {
-                if (propName[0] == "#") {
-                    var quotedPropName = getPropFuncInfo.quotedTextInfos[propName];
-                    if (!quotedPropName) {
-                        throw new Error("Cannot find quoted text for " + quotedPropName);
-                    }
-                    propName = eval(quotedPropName);
-                    token.propName = propName;
-                }
-                else {
-                    var statement_1 = "'use strict';\n";
-                    if (getPropFuncInfo.objParameterName) {
-                        statement_1 += "var " + getPropFuncInfo.objParameterName + " = arguments[1];\n";
-                    }
-                    if (getPropFuncInfo.cxtParameterName) {
-                        statement_1 += "var " + getPropFuncInfo.cxtParameterName + " = arguments[2];\n";
-                    }
-                    statement_1 += "" + propName;
-                    token.propName = undefined;
-                    token.getPropName = function (obj, context) {
-                        return evalStatement(statement_1, obj, context);
-                    };
-                }
-            }
-        };
-        for (var propIndex = 0; propIndex < getPropFuncInfo.funcTokens.length; ++propIndex) {
-            _loop_1();
-        }
-    }
-    function getAccessorTextInfo(bodyText, option) {
-        var returnIndex = bodyText.indexOf("return ");
-        if (!option.disableAllCheck && !option.disableHasReturnCheck) {
-            if (returnIndex <= -1) {
-                throw new Error("getProp() function has no 'return' keyword.");
-            }
-        }
-        if (!option.disableAllCheck && !option.disableExtraStatementCheck) {
-            var otherBodyText = bodyText.substr(0, returnIndex);
-            otherBodyText = otherBodyText.replace(/['"]use strict['"];*/g, "");
-            otherBodyText = otherBodyText.trim();
-            if (otherBodyText != "") {
-                throw new Error("getProp() function has statements other than 'return': " + otherBodyText);
-            }
-        }
-        var accessorText = bodyText.substr(returnIndex + 7).trim();
-        if (accessorText[accessorText.length - 1] == ";") {
-            accessorText = accessorText.substring(0, accessorText.length - 1);
-        }
-        accessorText = accessorText.trim();
-        return parseTextInQuotes(accessorText, option);
-    }
-    function parseTextInQuotes(accessorText, option) {
-        var quotedTextInfos = {};
-        var index = 0;
-        while (true) {
-            var singleQuoteIndex = accessorText.indexOf("'");
-            var doubleQuoteIndex = accessorText.indexOf('"');
-            var varName = "#" + index++;
-            if (singleQuoteIndex <= -1 && doubleQuoteIndex <= -1)
-                break;
-            var matches = undefined;
-            var quoteIndex = void 0;
-            if (doubleQuoteIndex > -1 && (doubleQuoteIndex < singleQuoteIndex || singleQuoteIndex <= -1)) {
-                matches = /("[^"\\]*(?:\\.[^"\\]*)*")/.exec(accessorText);
-                quoteIndex = doubleQuoteIndex;
-            }
-            else if (singleQuoteIndex > -1 && (singleQuoteIndex < doubleQuoteIndex || doubleQuoteIndex <= -1)) {
-                matches = /('[^'\\]*(?:\\.[^'\\]*)*')/.exec(accessorText);
-                quoteIndex = singleQuoteIndex;
-            }
-            if (matches) {
-                quotedTextInfos[varName] = matches[1];
-                accessorText =
-                    accessorText.substr(0, quoteIndex) +
-                        varName +
-                        accessorText.substr(matches.index + matches[1].length);
-            }
-            else {
-                throw new Error("Invalid text in quotes: " + accessorText);
-            }
-        }
-        return {
-            accessorText: accessorText,
-            quotedTextInfos: quotedTextInfos,
-        };
     }
     function quickCopy(value, propName, useConstructor, copyFunc) {
         if (value != undefined && !(value instanceof Date)) {
@@ -429,31 +235,6 @@
         }
         return destination;
     }
-    function evalStatement() {
-        return eval(arguments[0]);
-    }
-    // function isTextInQuote(text: string): boolean {
-    //     let quoteMarks = ["'", '"'];
-    //     for (let mark of quoteMarks) {
-    //         if (text[0] == mark && text[text.length-1] == mark) {
-    //             return true;
-    //         }
-    //     }
-    //     return false;
-    // }
-    // function extractTextInQuote(text: string): string {
-    //     let quoteMarks = ["'", '"'];
-    //     for (let mark of quoteMarks) {
-    //         if (text[0] == mark) {
-    //             let regex = new RegExp(`^[${mark}]([^${mark}]*)[${mark}]$`);
-    //             let match = regex.exec(text);
-    //             if (match) {
-    //                 return match[1];
-    //             }
-    //         }
-    //     }
-    //     return undefined;
-    // }
     iassign.default = iassign;
     return iassign;
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "target": "es5",
         "module": "commonjs",
+        "lib": ["es2015"],
         "removeComments": false,
         "jsx": "preserve" /*,
         "declaration": true */


### PR DESCRIPTION
I'm a big fan of this library and have come to the conclusion that it's the only realistic option available for managing immutable data in a Typescript project. Unfortunately, security requirements of my latest project include `content-security-policy` headers which prevents the use of eval at the browser level. After a lot of research looking for alternative libraries (there aren't any) and a bit of research into javascript meta-programming I arrived at the following solution.

I have replaced the core string parsing approach of the library by passing a Proxy object to the `getProp` function that traces the access path of the returned data. There are no changes to the public interface and tests pass locally, but testing in IE 11 will need a polyfill (see below).

### On performance
This eliminates the fixed cost of parsing the `getProp` function and trades it for a cost per level of depth when writing. In practice reads are unaffected, shallow writes are faster, and very deep writes are slower.

### On compatibility
Proxy objects [are supported in all modern browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#Browser_compatibility) and support can be added to legacy browsers with the very small [`proxy-polyfill`](https://github.com/GoogleChrome/proxy-polyfill) from Google. I could see an argument for making it an optional dependency and auto-including it from within ImmutableAssign but I have not done that here.