### PR TITLE
Make proxy-polyfill an optional dependency loaded from node_modules

### DIFF
--- a/deploy/iassign.js
+++ b/deploy/iassign.js
@@ -3,17 +3,22 @@
     if (typeof module === 'object' && typeof module.exports === 'object') {
         try {
             var deepFreeze = require("deep-freeze-strict");
-            var proxyPolyfill = require('./Libs/proxy');
         }
         catch (ex) {
             console.warn("Cannot load deep-freeze-strict module, however you can still use iassign() function.");
+        }
+        try {
+            var proxyPolyfill = require('proxy-polyfill');
+        }
+        catch (ex) {
+            console.warn("Cannot load proxy-polyfill module. iassign() will not work in IE 11 or other old browsers.");
         }
         var v = factory(deepFreeze, proxyPolyfill, exports);
         if (v !== undefined)
             module.exports = v;
     }
     else if (typeof define === 'function' && define.amd) {
-        define(["deep-freeze-strict", './Libs/proxy', "exports"], factory);
+        define(["deep-freeze-strict", 'proxy-polyfill', "exports"], factory);
     }
     else {
         // Browser globals (root is window)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   ],
   "dependencies": {},
   "optionalDependencies": {
-    "deep-freeze-strict": "^1.1.1"
+    "deep-freeze-strict": "^1.1.1",
+    "proxy-polyfill": "^0.1.7"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.74",
@@ -61,7 +62,6 @@
     "karma-sauce-launcher": "^1.1.0",
     "lodash": "^4.13.1",
     "merge2": "^1.0.2",
-    "proxy-polyfill": "^0.1.7",
     "seamless-immutable": "^7.0.1",
     "timm": "^1.2.3",
     "typescript": "^2.3.2",

--- a/src/iassign.js
+++ b/src/iassign.js
@@ -3,17 +3,22 @@
     if (typeof module === 'object' && typeof module.exports === 'object') {
         try {
             var deepFreeze = require("deep-freeze-strict");
-            var proxyPolyfill = require('./Libs/proxy');
         }
         catch (ex) {
             console.warn("Cannot load deep-freeze-strict module, however you can still use iassign() function.");
+        }
+        try {
+            var proxyPolyfill = require('proxy-polyfill');
+        }
+        catch (ex) {
+            console.warn("Cannot load proxy-polyfill module. iassign() will not work in IE 11 or other old browsers.");
         }
         var v = factory(deepFreeze, proxyPolyfill, exports);
         if (v !== undefined)
             module.exports = v;
     }
     else if (typeof define === 'function' && define.amd) {
-        define(["deep-freeze-strict", './Libs/proxy', "exports"], factory);
+        define(["deep-freeze-strict", 'proxy-polyfill', "exports"], factory);
     }
     else {
         // Browser globals (root is window)

--- a/src/iassign.ts
+++ b/src/iassign.ts
@@ -63,15 +63,20 @@ interface IIassign extends IIassignOption {
     if (typeof module === 'object' && typeof module.exports === 'object') {
         try {
             var deepFreeze: DeepFreeze.DeepFreezeInterface = require("deep-freeze-strict");
-            var proxyPolyfill = require('./Libs/proxy');
         } catch (ex) {
             console.warn("Cannot load deep-freeze-strict module, however you can still use iassign() function.");
+        }
+
+        try {
+            var proxyPolyfill = require('proxy-polyfill');
+        } catch (ex) {
+            console.warn("Cannot load proxy-polyfill module. iassign() will not work in IE 11 or other old browsers.");
         }
 
         var v = factory(deepFreeze, proxyPolyfill, exports); if (v !== undefined) module.exports = v;
     }
     else if (typeof define === 'function' && define.amd) {
-        define(["deep-freeze-strict", './Libs/proxy', "exports"], factory);
+        define(["deep-freeze-strict", 'proxy-polyfill', "exports"], factory);
     } else {
         // Browser globals (root is window)
         root.iassign = factory(root.deepFreeze, undefined, {});


### PR DESCRIPTION
One minor issue with using this library is that it now loads its own local copy of `proxy-polyfill` even though I already have it specified in my own project's dependencies. The local copy of the polyfill is still being loaded for tests after these changes thanks to karma.conf.js L114